### PR TITLE
Fix broken Astro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run dev
 ## Built with 🛠️
 
 * [Figma](https://www.figma.com/) - Herramienta de Diseño y Prototipado
-* [Astro]([https://es.reactjs.org/](https://astro.build/)) - Framework Javascript
+* [Astro](https://astro.build/) - Framework Javascript
 * [Tailwind](https://tailwindcss.com/) - Styles
 
 


### PR DESCRIPTION
## Summary
- fix markdown syntax for Astro link in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ce61eee48325b600b61fa5b9ade1