### PR TITLE
Fix getLastWord return path

### DIFF
--- a/src/utils/getLastWord.ts
+++ b/src/utils/getLastWord.ts
@@ -2,7 +2,9 @@ export async function getLastWord(sentence: string) {
   sentence = sentence.trim();
   const lastSpaceIndex = sentence.lastIndexOf(" ");
 
-  if (lastSpaceIndex === -1) ({ text: sentence, lastWord: "" });
+  if (lastSpaceIndex === -1) {
+    return { text: sentence, lastWord: "" };
+  }
 
   return {
     text: sentence.substring(0, lastSpaceIndex),


### PR DESCRIPTION
## Summary
- ensure `getLastWord` always returns an object

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ce78c33483259529424d4c7d21f2